### PR TITLE
Support relative path for sub-path deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import visualizer from 'rollup-plugin-visualizer'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   build: {
     rollupOptions: {

--- a/web/pages/Files.tsx
+++ b/web/pages/Files.tsx
@@ -176,7 +176,7 @@ const Item: React.FC<{ plugin: Plugin, path: string, loading: Record<string, () 
             key={it}
             nodeId={path + '/' + it}
             label={<><Icon className='icon'>
-              <embed src={`/icons/material/${icons.icons[id] || 'file'}.svg`} />
+              <embed src={`./icons/material/${icons.icons[id] || 'file'}.svg`} />
             </Icon>{it}</>}
           />
         }))
@@ -186,7 +186,7 @@ const Item: React.FC<{ plugin: Plugin, path: string, loading: Record<string, () 
     return path
       ? <StyledTreeItem nodeId={path} onClick={() => setOpen(!open)} label={<>
         <Icon className='icon'>
-          <embed src={`/icons/material/${icons.icons[(icons as any).folders[name]] || 'folder'}${open ? '-open' : ''}.svg`} />
+          <embed src={`./icons/material/${icons.icons[(icons as any).folders[name]] || 'folder'}${open ? '-open' : ''}.svg`} />
         </Icon>{name}
       </>}>{children}</StyledTreeItem>
       : <>{children}</>


### PR DESCRIPTION
This PR let the web-end support be deployed in a sub-path, for example `https://neko-craft/maid`.
So every resource will use relative path.