### PR TITLE
Remove ANSI color code in terminal logs for now

### DIFF
--- a/web/utils.tsx
+++ b/web/utils.tsx
@@ -153,7 +153,9 @@ export const parseStyledText = (it: string) => {
   return <>{a.slice(1)}{b && <span style={style}>{b[0] === '§' ? parseStyledText(b) : b}</span>}</>
 }
 export const parseMessage = (msg: string) => {
-  const msgClean = msg.replace(/\u007f(#[0-9a-f]{6}|.)/g, ''); // Let DEL symbol delete later character. Sometimes there would be hex color after DEL symbol.
+  const msgClean = msg
+      .replace(/\u007f(#[0-9a-f]{6}|.)/g, '') // Let DEL symbol delete later character. Sometimes there would be hex color after DEL symbol.
+      .replace(/\u001b\[[0-9;]+m/g, ''); // TODO: Remove ANSI color code for now, until this project support this in Terminal.
   const arr = msgClean.replace(/§k/g, '').split(/(?=§[0-9a-fA-FxXrR])/g)
   const res: JSX.Element[] = []
   let color = ''


### PR DESCRIPTION
Some plugins would use ANSI color code for system console.
But it seems NekoMaid didn't support it right now.
So I use regexps to remove them, until this project is about support them.